### PR TITLE
UN-3217 Add AsyncioExecutorPool module.

### DIFF
--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -107,6 +107,8 @@ class AsyncioExecutor(Executor):
         pending = asyncio.all_tasks(loop=loop)
         if pending:
             loop.run_until_complete(asyncio.gather(*pending, return_exceptions=False))
+        # Close the event loop to free its related resources
+        loop.close()
 
     @staticmethod
     def loop_exception_handler(loop: AbstractEventLoop, context: Dict[str, Any]):

--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -264,6 +264,16 @@ class AsyncioExecutor(Executor):
                      False otherwise.  Default is True.
         :param cancel_futures: Ignored? Default is False.
         """
+        # Here is an outline of how this call works:
+        # 1. shutdown() tells event loop to stop
+        # (telling loop to execute loop.stop(), and doing this from caller thread by call_soon_threadsafe())
+        #  then it starts to wait to join executor thread;
+        # 2. executor thread returns from loop.run_forever(), because event loop has stopped,
+        # does some finishing with outstanding loop tasks, and closes the loop. Then executor thread finishes.
+        # Note that closing event loop frees loop-bound resources which otherwise
+        # are not necessarily released.
+        # 3. shutdown() joins the finished executor thread and peacefully finishes itself.
+        # 4. shutdown() call returns to caller.
         self._shutdown = True
         self._loop.call_soon_threadsafe(self._loop.stop)
         if wait:

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -1,0 +1,69 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+import logging
+import threading
+from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
+
+
+class AsyncioExecutorPool:
+    """
+    Class maintaining a dynamic set of reusable AsyncioExecutor instances.
+    """
+
+    def __init__(self, reuse_mode: bool = True):
+        """
+        Constructor.
+        :param reuse_mode: True, if requested executor instances
+                                 are taken from pool of available ones (pool mode);
+                           False, if requested executor instances are created new
+                                 and shutdown on return (backward compatible mode)
+        """
+        self.reuse_mode: bool = reuse_mode
+        self.pool = []
+        self.lock: threading.Lock = threading.Lock()
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.debug("AsyncioExecutorPool created: %s reuse: %s",
+                         id(self), str(self.reuse_mode))
+
+    def get_executor(self) -> AsyncioExecutor:
+        """
+        Get active (running) executor from the pool
+        :return: AsyncioExecutor instance
+        """
+        if self.reuse_mode:
+            with self.lock:
+                if len(self.pool) > 0:
+                    result = self.pool.pop(0)
+                    self.logger.debug("Reusing AsyncioExecutor %s", id(result))
+                    return result
+        # Create AsyncioExecutor outside of lock
+        # to avoid potentially longer locked periods
+        result = AsyncioExecutor()
+        result.start()
+        self.logger.debug("Creating AsyncioExecutor %s", id(result))
+        return result
+
+    def return_executor(self, executor: AsyncioExecutor):
+        """
+        Return AsyncioExecutor instance back to the pool of available instances.
+        :param executor: AsyncioExecutor to return.
+        """
+        if self.reuse_mode:
+            with self.lock:
+                self.pool.append(executor)
+                self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d", id(executor), len(self.pool))
+        else:
+            # Shutdown AsyncioExecutor outside of lock
+            # to avoid potentially longer locked periods
+            self.logger.debug("Shutting down: AsyncioExecutor %s", id(executor))
+            executor.shutdown()

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -9,6 +9,9 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+"""
+See class comments
+"""
 
 import logging
 import threading
@@ -33,7 +36,7 @@ class AsyncioExecutorPool:
         self.lock: threading.Lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.debug("AsyncioExecutorPool created: %s reuse: %s",
-                         id(self), str(self.reuse_mode))
+                          id(self), str(self.reuse_mode))
 
     def get_executor(self) -> AsyncioExecutor:
         """


### PR DESCRIPTION
This PR implements a very simple pooling for AsyncExecutors.
The initial goal here is to solve outstanding issue with neuro-san service: namely to compensate for (unknown to us) httpx connections pooling policy, which results in transport connection being closed at some unpredictable moment in time, after our request is already processed and underlying AsyncExecutor is shutdown.
With pooling, we basically keep all our AsyncExecutors alive and running, with their event loops active and available for incoming "close this connection" task. There is also some performance advantage in not creating AsyncExecutor from scratch for each request , with thread creation/starting and all.
We can still specify "backward compatibility" mode for the pool with pass-thru creation and shutdown for each AsyncExecutor.

Tested: usual stress tests for both OpenAI and AzureOpenAI models with no exceptions observed.