### PR TITLE
UN-3434 Handle task CancelledError exception.

### DIFF
--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -240,6 +240,10 @@ class AsyncioExecutor(Executor):
             except TimeoutError:
                 print(f"Coroutine from {origination} took too long()")
 
+            except asyncio.exceptions.CancelledError:
+                # Cancelled task is OK - it may happen for different reasons.
+                print(f"Task from {origination} was cancelled")
+
             # pylint: disable=broad-exception-caught
             except Exception as exception:
                 print(f"Coroutine from {origination} raised an exception:")

--- a/leaf_common/utils/async_atomic_counter.py
+++ b/leaf_common/utils/async_atomic_counter.py
@@ -1,0 +1,55 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+import asyncio
+
+
+class AsyncAtomicCounter:
+    """
+    Class implements atomic incrementing counter for async execution environment.
+    """
+    def __init__(self, start: int = 0):
+        """
+        Constructor
+
+        :param value: The initial value of the counter. Default is 0.
+        """
+        self._value = start
+        self._lock = asyncio.Lock()
+
+    async def increment(self, step: int = 1) -> int:
+        """
+        Increment the counter and return the new value
+        as an atomic operation.
+
+        :param step: The amount by which the counter should be incremented.
+                     Default is 1.
+        """
+        async with self._lock:
+            self._value += int(step)
+            return self._value
+
+    async def decrement(self, step: int = 1) -> int:
+        """
+        Decrement the counter and return the new value
+        as an atomic operation.
+
+        :param step: The amount by which the counter should be decremented.
+                     Default is 1.
+        """
+        return await self.increment(-step)
+
+    async def get_count(self) -> int:
+        """
+        :return: The value of the counter.
+        """
+        return self._value

--- a/leaf_common/utils/async_atomic_counter.py
+++ b/leaf_common/utils/async_atomic_counter.py
@@ -9,7 +9,9 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
-
+"""
+See class comments for description.
+"""
 import asyncio
 
 

--- a/leaf_common/utils/atomic_counter.py
+++ b/leaf_common/utils/atomic_counter.py
@@ -9,6 +9,9 @@
 # leaf-server-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
+"""
+See class comments for description.
+"""
 import threading
 
 

--- a/leaf_common/utils/atomic_counter.py
+++ b/leaf_common/utils/atomic_counter.py
@@ -1,0 +1,55 @@
+
+# Copyright (C) 2019-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# leaf-server-common SDK Software in commercial settings.
+#
+# END COPYRIGHT
+import threading
+
+
+class AtomicCounter:
+    """
+    A class for thread-safe increment/decrement of a counter shared among threads.
+    """
+
+    def __init__(self, value: int = 0):
+        """
+        Constructor
+
+        :param value: The initial value of the counter. Default is 0.
+        """
+        self._value = int(value)
+        self._lock = threading.Lock()
+
+    def increment(self, step: int = 1) -> int:
+        """
+        Increment the counter and return the new value
+        as an atomic operation.
+
+        :param step: The amount by which the counter should be incremented.
+                     Default is 1.
+        """
+        with self._lock:
+            self._value += int(step)
+            return self._value
+
+    def decrement(self, step: int = 1) -> int:
+        """
+        Decrement the counter and return the new value
+        as an atomic operation.
+
+        :param step: The amount by which the counter should be decremented.
+                     Default is 1.
+        """
+        self.increment(-step)
+
+    def get_count(self) -> int:
+        """
+        :return: The value of the counter.
+        """
+        return self._value


### PR DESCRIPTION
This PR does 2 things:

- In AsyncioExecutor loop "submission_done" callback adds handling of asyncio.exceptions.CancelledError exception,
   similar to how we handle TimeoutError exception, that is - by logging it to standard output. The reason why this exception   was not caught before is because it is not a subclass of Exception, but rather BaseException;

- 2 useful helper classes: AsyncAtomicCounter and AtomicCounter are pushed down here from neuro-san repo and leaf-server-common repo.
  