### PR TITLE
UN-3377 Potential AsyncioExecutor race condition.

### DIFF
--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -77,7 +77,7 @@ class AsyncioExecutor(Executor):
             return
 
         self._thread = threading.Thread(target=self.loop_manager,
-                                        args=(self._loop, self._loop_ready, self._startup_function),
+                                        args=(self._loop, self._loop_ready),
                                         daemon=True)
         self._thread.start()
         timeout: int = EXECUTOR_START_TIMEOUT_SECONDS

--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -112,13 +112,16 @@ class AsyncioExecutor(Executor):
         :param startup_function: callable object to be executed by loop_manager
             before anything else
         """
+        print(">>>>>>>>>>>> LOOP MANAGER start")
         if startup_function is not None:
+            print(">>>>>>>>>>>> HAVE STARTUP FUNCTION!")
             try:
                 print(">>>>>>>>>>> STARTUP CALL")
                 startup_function()
                 print(">>>>>>>>>>> STARTUP CALL DONE")
             except Exception as exc:  # pylint: disable=broad-except
                 print(f"Loop manager startup function exception: {exc}")
+        print(">>>>>>>>>>>> LOOP MANAGER end")
 
         asyncio.set_event_loop(loop)
         loop.call_soon(AsyncioExecutor.notify_loop_ready, loop_ready)

--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -71,7 +71,9 @@ class AsyncioExecutor(Executor):
         return self._loop
 
     def set_startup_function(self, function: Callable):
+        print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
         self._startup_function = function
+        print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
 
     def start(self):
         """

--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -101,7 +101,7 @@ class AsyncioExecutor(Executor):
     @staticmethod
     def loop_manager(loop: AbstractEventLoop,
                      loop_ready: threading.Event,
-                     startup_function: Callable = None):
+                     startup_function: Callable):
         """
         Entry point static method for the background thread.
 


### PR DESCRIPTION
This PR is an attempt to fix potential race condition in our per-request event loops,
where setting up request-related environment (like setting up logging metadata) could race with the first user request coming in.
