### PR TITLE
UN-3385 Allow for lazy imports in Resolver and ResolverUtil

### DIFF
--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -37,7 +37,7 @@ class Resolver():
         self.packages: List[str] = packages
 
     # pylint: disable=too-many-positional-arguments,too-many-arguments
-    def resolve_class_in_module(self, class_name: str, module_name: str = None,
+    def resolve_class_in_module(self, class_name: str, module_name: str = None,     # noqa: C901
                                 raise_if_not_found: bool = True,
                                 verbose: bool = False,
                                 install_if_missing: str = None) -> Type[Any]:
@@ -87,7 +87,10 @@ class Resolver():
         elif verbose:
             logger.info("Found module %s", use_module_name)
 
-        my_class: Type[Any] = getattr(found_module, class_name)
+        my_class: Type[Any] = None
+        if found_module is not None:
+            my_class = getattr(found_module, class_name)
+
         return my_class
 
     def try_to_import_module(self, module: str, messages: List[str],

--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -87,6 +87,7 @@ class Resolver():
         elif verbose:
             logger.info("Found module %s", use_module_name)
 
+        # The None case here should only fall through if raise_not_found is False.
         my_class: Type[Any] = None
         if found_module is not None:
             my_class = getattr(found_module, class_name)

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -103,6 +103,7 @@ class ResolverUtil:
 
     @staticmethod
     def create_type(fully_qualified_name: str,
+                    raise_if_not_found: bool = True,
                     install_if_missing: str = None) -> Type[Any]:
         """
         :param fully_qualified_name: The fully qualified name of the class to create
@@ -119,7 +120,7 @@ class ResolverUtil:
         resolver = Resolver()
         class_type: Type[Any] = resolver.resolve_class_in_module(class_name,
                                                                  module_name=module_name,
-                                                                 raise_if_not_found=False,
+                                                                 raise_if_not_found=raise_if_not_found,
                                                                  install_if_missing=install_if_missing)
         return class_type
 
@@ -143,7 +144,9 @@ class ResolverUtil:
         for class_name in type_list:
 
             # Try to resolve the single type and append to list if we get it.
-            one_type: Type[Any] = ResolverUtil.create_type(class_name, install_if_missing=None)
+            one_type: Type[Any] = ResolverUtil.create_type(class_name,
+                                                           raise_if_not_found=False,
+                                                           install_if_missing=None)
             if one_type is not None:
                 tuple_list.append(one_type)
 

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -107,8 +107,10 @@ class ResolverUtil:
                     install_if_missing: str = None) -> Type[Any]:
         """
         :param fully_qualified_name: The fully qualified name of the class to create
+        :param raise_if_not_found: Raise an exception if the class is not found when True.
         :param install_if_missing: The pip package to install if the class is not found
-        :return: The class referenced (not an instance of the class)
+        :return: The class referenced (*not* an instance of the class).
+                 Can return None if the class is not found and raise_if_not_found is False.
         """
         if not fully_qualified_name:
             return None

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -15,6 +15,7 @@ See class comment for details.
 
 from typing import Any
 from typing import List
+from typing import Tuple
 from typing import Type
 
 from leaf_common.config.resolver import Resolver
@@ -99,3 +100,51 @@ class ResolverUtil:
             )
 
         return class_reference
+
+    @staticmethod
+    def create_type(fully_qualified_name: str,
+                    install_if_missing: str = None) -> Type[Any]:
+        """
+        :param fully_qualified_name: The fully qualified name of the class to create
+        :param install_if_missing: The pip package to install if the class is not found
+        :return: The class referenced (not an instance of the class)
+        """
+        if not fully_qualified_name:
+            return None
+
+        name_split: List[str] = fully_qualified_name.split(".")
+        module_name: str = ".".join(name_split[:-1])
+        class_name: str = name_split[-1]
+
+        resolver = Resolver()
+        class_type: Type[Any] = resolver.resolve_class_in_module(class_name,
+                                                                 module_name=module_name,
+                                                                 raise_if_not_found=False,
+                                                                 install_if_missing=install_if_missing)
+        return class_type
+
+    @staticmethod
+    def create_type_tuple(type_list: List[str]) -> Tuple[Type[Any], ...]:
+        """
+        Creates a tuple of class types for use in isinstance(obj, <tuple_of_types>)
+        situations.
+
+        :param type_list: A list of fully qualified names of the types to create
+                          (not class instances) to the string name of the package to install
+                          if the class is not found.
+        :return: A tuple of the class types that could be resolved.
+                Can return an empty tuple if nothing in the type_list could be resolved
+        """
+
+        if not type_list:
+            return ()
+
+        tuple_list: List[Type[Any]] = []
+        for class_name in type_list:
+
+            # Try to resolve the single type and append to list if we get it.
+            one_type: Type[Any] = ResolverUtil.create_type(class_name, install_if_missing=None)
+            if one_type is not None:
+                tuple_list.append(one_type)
+
+        return tuple(tuple_list)


### PR DESCRIPTION
* Allow for lazily loading classes that might not exist in Resolver.resolve_class_in_module(). Return None for these cases.
* Add a new method ResolverUtil.create_type() which can create a single type from a single fully qualified string
* Add ResolverUtil.create_type_tuple() method which will create tuples of types from a string list for use in isinstance() and except clauses.